### PR TITLE
Changing unit test to PyTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /venv/
 /.idea/
 /.tox/
+/htmlcov/

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
 envlist =
-    # Cleanup
-    coverage-clean
     # Code style
     flake8
     isort
@@ -11,8 +9,6 @@ envlist =
 #    py{310,311}-docstr-coverage
     # Tests
     py{310}
-    # Coverage
-    coverage-report
 #requires =
 #    tox-pipenv
 #    setuptools >= 57.0.0
@@ -26,17 +22,14 @@ deps =
     testing.postgresql
     sqlalchemy-stubs
     urllib3-mock
+    pytest
+    pytest-cov
+    pytest-html
 commands =
     #{envpython} setup.py test
-    python -m coverage run -p -m unittest discover {posargs:tests}
+    python -m coverage run -m pytest --cov --cov-report xml --cov-report html --html=./test-report.html --self-contained-html
 extra = tests
 #basepython = python3.10
-
-[testenv:coverage-clean]
-deps =
-    coverage
-skip_install = true
-commands = coverage erase
 
 [testenv:isort]
 deps =
@@ -75,15 +68,6 @@ description = Run the mypy tool to check static typing on the project.
 #[testenv:doc8]
 
 #[testenv:docstr-coverage]
-
-[testenv:coverage-report]
-deps = coverage
-skip_install = true
-commands =
-    coverage combine
-    coverage report
-    coverage html
-    coverage xml
 
 ####################
 # Deployment tools #


### PR DESCRIPTION
Change unittest to PyTest and adding HTML test reporting.

As the unittest are quite big, html report makes easier to check what test is failing and why.