### PR TITLE
Adding tag checkout in CI action for versioneer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
+      - name: Checkout tags
+        run: git fetch --prune --unshallow
       - name: Install dependencies
         run: python -m pip install -U tox versioneer tox-gh-actions
       - name: Run tox


### PR DESCRIPTION
actions/checkout does not fetch tags, this causes versioneer to create an untagged version.

adding force tags checkout to fix versioneer